### PR TITLE
Make use of new dce_lti_py, django-auth-lti and django-canvas-api-token ...

### DIFF
--- a/course_admin/validator.py
+++ b/course_admin/validator.py
@@ -1,0 +1,54 @@
+from django.core.exceptions import ImproperlyConfigured
+from oauthlib.oauth1 import RequestValidator
+from oauthlib.common import to_unicode
+from django.conf import settings
+import redis
+import time
+
+import logging
+log = logging.getLogger(__name__)
+
+NONCE_TTL = 3600 * 6
+
+class LTIRequestValidator(RequestValidator):
+
+    enforce_ssl = False
+
+    dummy_secret = 'secret'
+    dummy_client = (u'dummy_'
+        '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')
+
+    def check_client_key(self, key):
+        # any non-empty string is OK as a client key
+        return len(key) > 0
+
+    def check_nonce(self, nonce):
+        # any non-empty string is OK as a nonce
+        return len(nonce) > 0
+
+    def validate_client_key(self, client_key, request):
+        return client_key in settings.LTI_OAUTH_CREDENTIALS
+
+    def validate_timestamp_and_nonce(self, client_key, timestamp, nonce,
+                                     request, request_token=None,
+                                     access_token=None):
+        try:
+            r = redis.from_url(settings.REDIS_URL)
+            r.ping()
+        except redis.ConnectionError, e:
+            raise ImproperlyConfigured("redis connect failure: " + str(e))
+
+        exists = r.getset('nonce:' + nonce, timestamp)
+        if exists:
+            log.debug("nonce already exists: %s", nonce)
+            return False
+        else:
+            log.debug("unused nonce, storing: %s", nonce)
+            r.expire('nonce:' + nonce, int(timestamp) + NONCE_TTL)
+            return True
+
+    def get_client_secret(self, client_key, request):
+        secret = settings.LTI_OAUTH_CREDENTIALS.get(client_key, self.dummy_secret)
+        # make sure secret val is unicode
+        return to_unicode(secret)
+

--- a/course_admin/views.py
+++ b/course_admin/views.py
@@ -5,7 +5,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from ims_lti_py.tool_config import ToolConfig
+from dce_lti_py.tool_config import ToolConfig
 from canvas_api_token.decorators import api_token_required
 from canvas import CanvasApi, CourseUpdateError
 from time import sleep

--- a/dce_course_admin/settings.py
+++ b/dce_course_admin/settings.py
@@ -47,6 +47,7 @@ WSGI_APPLICATION = 'dce_course_admin.wsgi.application'
 
 AUTHENTICATION_BACKENDS = (
     'django_auth_lti.backends.LTIAuthBackend',
+    'django.contrib.auth.backends.ModelBackend'
 )
 
 TIME_ZONE = 'UTC'
@@ -97,18 +98,13 @@ DATABASES = {
         engine=env('DJANGO_DATABASE_DEFAULT_ENGINE', None))
 }
 
+REDIS_URL = env('REDIS_URL')
+
+LTI_REQUEST_VALIDATOR = 'course_admin.validator.LTIRequestValidator'
+
 LTI_OAUTH_CREDENTIALS = {
     env('LTI_OAUTH_COURSE_ADMIN_CONSUMER_KEY'): env(
         'LTI_OAUTH_COURSE_ADMIN_CONSUMER_SECRET')
-}
-
-LTI_APP_DEVELOPER_KEYS = {
-    # These values must be obtained by registering the LTI app with the canvas instance
-    # See: <instance_base_url>/developer_keys
-    env('LTI_OAUTH_COURSE_ADMIN_CONSUMER_KEY'): {
-        'client_id': env('CANVAS_DEVELOPER_KEY_CLIENT_ID'),
-        'client_secret': env('CANVAS_DEVELOPER_KEY_CLIENT_SECRET')
-    }
 }
 
 CURRENT_TERM_ID = env('CURRENT_TERM_ID')
@@ -144,7 +140,6 @@ LOGGING = {
         },
         'console': {
             'level': 'DEBUG',
-            'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
             'formatter': 'main_formatter',
         },

--- a/dce_course_admin/urls.py
+++ b/dce_course_admin/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import patterns, include, url
+from django.contrib import admin
 
 urlpatterns = patterns('',
     url(r'^course_admin/', include('course_admin.urls')),
-    url(r'^canvas_api_token/', include('canvas_api_token.urls'))
+    url(r'^canvas_api_token/', include('canvas_api_token.urls')),
+    url(r'^admin/', include(admin.site.urls))
 )

--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -9,24 +9,25 @@
 5. Add the required heroku add-ons: 
     * [Heroku Postgres](https://addons.heroku.com/heroku-postgresql) 
     * [Mandrill](https://addons.heroku.com/mandrill)
+    * [RedisToGo](https://elements.heroku.com/addons/redistogo)
 6. Set up the remaining environment vars via `heroku config:set ...` (see below)
 7. Run `git push heroku master`. Heroku will detect and build the app.
-8. Run `heroku run python manage.py syncdb` to initialize the database. 
-    * Say, 'no', when prompted to create an admin user.
+8. Run `heroku run python manage.py migrate` to initialize the database. 
+    * Say, 'yes', when prompted to create an admin user. This is necessary for setting up the canvas developer key.
+9. Visit `https://<app_url>/admin`, login using the super user created in the previous step, and enter your Canvas developer key.
+    * Note: the redirect URI used to initially create the developer key via the Canvas admin must match `https://<app_url>`.
 9. Install the LTI app in the Canvas account settings UI. 
     * Configuration Type: 'By URL'
     * Name: 'DCE Course Admin'
     * Consumer Key: value of the **LTI_OAUTH_COURSE_ADMIN_CONSUMER_KEY** env var
     * Consumer Secret: value of the **LTI_OAUTH_COURSE_ADMIN_CONSUMER_SECRET** env var
-    * Config URL: https://dce-course-admin.herokuapp.com/course_admin/tool_config
+    * Config URL: `https://<app_url>/course_admin/tool_config`
 
 ### Required env vars
 
 ```
 LTI_OAUTH_COURSE_ADMIN_CONSUMER_KEY=...
 LTI_OAUTH_COURSE_ADMIN_CONSUMER_SECRET=...
-CANVAS_DEVELOPER_KEY_CLIENT_ID=...
-CANVAS_DEVELOPER_KEY_CLIENT_SECRET=...
 DJANGO_SECRET_KEY=...
 DJANGO_ADMIN_NAME=...
 DJANGO_ADMIN_EMAIL=...
@@ -34,15 +35,16 @@ DJANGO_SERVER_EMAIL
 PYTHONPATH=fakepath
 DJANGO_DATABASE_DEFAULT_ENGINE=django_postgrespool
 CURRENT_TERM_ID=2014-2
+REDIS_URL=...
 ```
 
 * **LTI_OAUTH_COURSE_ADMIN_CONSUMER_KEY** and **LTI_OAUTH_COURSE_ADMIN_CONSUMER_SECRET** are credentials needed during the Canvas LTI app installation. The key should be some simple, identifying string, like "dce-course-admin". For the secret you can probably just use a generated password or a [uuid4](http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29), but if you want to get fancy there's a [secret key generator](http://techblog.leosoto.com/django-secretkey-generation/) that I sometimes use.
-* **CANVAS_DEVELOPER_KEY_CLIENT_ID** and **CANVAS_DEVELOPER_KEY_CLIENT_SECRET** are necessary for the oauth workflow the app uses to generate user-specific canvas api keys. See: https://canvas.instructure.com/doc/api/file.oauth.html. Note that the domain of the app (eg, *https://dce-course-admin.herokuapp.com*) must match the value of the *REDIRECT_URI* used when generating this id/secret pair.
 * **DJANGO_SECRET_KEY**: see comments above about the *LTI_OAUTH_COURSE_ADMIN_CONSUMER_SECRET*.
 * **PYTHONPATH**: This is a common kludge to deal with [gunicorn weirdness on heroku](https://github.com/heroku/heroku-buildpack-python/wiki/Troubleshooting#no-module-named-appwsgiapp).
 * **DJANGO_ADMIN_NAME** and **DJANGO_ADMIN_EMAIL**: Set these to the name/email of the person or entity that will recieve app error notifications.
 * **DJANGO_SERVER_EMAIL**: app error notifications will use this as the "From:" address.
-* **CURRENT_TERM_ID**: this specifies which enrollment term should be the default view.
+* **CURRENT_TERM_ID**: this specifies which enrollment term should be the default view (currently listed in `settings.py`.
+* **REDIS_URL**: copy this from the **REDISTOGO_URL** that was inserted into your heroku config when the redis add-on was added.
 
 ### Additional env vars
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,10 +2,12 @@ Django==1.7.1
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-braces==1.3.1
-django-canvas-api-token==0.1.2
 django-dotenv==1.3.0
 django-getenv==1.3.1
 gunicorn==19.0.0
 requests==2.5.0
 drest==0.9.12
-git+https://github.com/Harvard-University-iCommons/django-auth-lti.git
+dce_lti_py==0.7.2
+redis==2.10.3
+django-canvas-api-token==0.2.0
+git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py


### PR DESCRIPTION
...improvements
- enable admin site
- django-canvas-api-token now stores developer keys in db
- new LTIRequestValidator class uses redis for nonce validation
