### PR TITLE
prevent pagination reset when toggle triggers table redraw

### DIFF
--- a/course_admin/templates/course_admin/course_list.html
+++ b/course_admin/templates/course_admin/course_list.html
@@ -283,7 +283,7 @@
                 var col_selector = data.name + ":name";
                 var cell = table.cell(row_selector, data.name + ":name");
                 var state = data.state == 'true'
-                cell.data(state).draw();
+                cell.data(state).draw(false);
                 // notify success
                 var course_title = table.cell(row_selector, 'name:name').render('sort');
                 var msg = 'Success!<br/>Set ' + data.name + ' = '


### PR DESCRIPTION
Fixes #4. Call to redraw the table after toggling a setting needed an additional parameter to prevent pagination reset.
